### PR TITLE
Move development process docs from Nengo

### DIFF
--- a/caa.rst
+++ b/caa.rst
@@ -1,0 +1,224 @@
+**************************************
+Nengo Contributor Assignment Agreement
+**************************************
+
+Based on Harmony (HA-CAA-I-ANY) Version 1.0, with minor changes.
+
+Individual Contributor Assignment Agreement
+===========================================
+
+Thank you for your interest in contributing to Nengo, a product of
+Applied Brain Research ("We" or "Us").
+
+This contributor agreement (the "Agreement") documents the rights
+granted by contributors to Us.
+
+By adding your name to the CONTRIBUTORS.rst file at
+<https://github.com/nengo/nengo/blob/master/CONTRIBUTORS.rst>
+you are agreeing to be bound by the Agreement in full.
+
+You agree to inform Us in the relevant pull request(s) if You do not own
+the Copyright to the entire Submission. We will initiate an IP review
+with You to determine the eligibility of the Submission before merging
+the pull request.
+
+This is a legally binding document, so please read it carefully before
+agreeing to it. The Agreement may cover more than one software project
+managed by Us.
+
+1. Definitions
+--------------
+
+"You" means the individual who Submits a Contribution to Us.
+
+"Contribution" means any work of authorship that is Submitted by You
+to Us in which You own or assert ownership of the Copyright.
+
+"Copyright" means all rights protecting works of authorship owned or
+controlled by You, including copyright, moral and neighboring rights,
+as appropriate, for the full term of their existence including any
+extensions by You.
+
+"Material" means the work of authorship which is made available by Us
+to third parties. When this Agreement covers more than one software
+project, the Material means the work of authorship to which the
+Contribution was Submitted. After You Submit the Contribution, it may
+be included in the Material.
+
+"Submit," "Submission" means any form of electronic, verbal, or written
+communication (including any and all Contributions and works of
+authorship) sent to Us or our representatives, including but not limited
+to electronic mailing lists, source code control systems, and issue
+tracking systems that are managed by, or on behalf of, Us for the
+purpose of discussing and improving the Material, but excluding
+communication that is conspicuously marked or otherwise designated in
+writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to
+Us.
+
+"Effective Date" means the date You execute this Agreement or the date
+You first Submit a Contribution to Us, whichever is earlier.
+
+2. Grant of Rights
+------------------
+
+2.1 Copyright Assignment
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+(a) At the time the Contribution is Submitted, You assign to Us all
+    right, title, and interest worldwide in all Copyright covering the
+    Contribution; provided that this transfer is conditioned upon
+    compliance with Section 2.3.
+
+(b) To the extent that any of the rights in Section 2.1(a) cannot be
+    assigned by You to Us, You grant to Us a perpetual, worldwide,
+    exclusive, royalty-free, transferable, irrevocable license under
+    such non-assigned rights, with rights to sublicense through
+    multiple tiers of sublicensees, to practice such non-assigned
+    rights, including, but not limited to, the right to reproduce,
+    modify, display, perform and distribute the Contribution; provided
+    that this license is conditioned upon compliance with Section 2.3.
+
+(c) To the extent that any of the rights in Section 2.1(a) can neither
+    be assigned nor licensed by You to Us, You irrevocably waive and
+    agree never to assert such rights against Us, any of our
+    successors in interest, or any of our licensees, either direct or
+    indirect; provided that this agreement not to assert is
+    conditioned upon compliance with Section 2.3.
+
+(d) Upon such transfer of rights to Us, to the maximum extent
+    possible, We immediately grant to You a perpetual, worldwide,
+    non-exclusive, royalty-free, transferable, irrevocable license
+    under such rights covering the Contribution, with rights to
+    sublicense through multiple tiers of sublicensees, to reproduce,
+    modify, display, perform, and distribute the Contribution. The
+    intention of the parties is that this license will be as broad as
+    possible and to provide You with rights as similar as possible to
+    the owner of the rights that You transferred. This license back is
+    limited to the Contribution and does not provide any rights to the
+    Material.
+
+2.2 Patent License
+^^^^^^^^^^^^^^^^^^
+
+For patent claims including, without limitation, method, process, and
+apparatus claims which You own, control or have the right to grant,
+now or in the future, You grant to Us a perpetual, worldwide,
+non-exclusive, transferable, royalty-free, irrevocable patent license,
+with the right to sublicense these rights to multiple tiers of
+sublicensees, to make, have made, use, sell, offer for sale, import
+and otherwise transfer the Contribution and the Contribution in
+combination with the Material (and portions of such combination). This
+license is granted only to the extent that the exercise of the
+licensed rights infringes such patent claims; and provided that this
+license is conditioned upon compliance with Section 2.3.
+
+2.3 Outbound License
+^^^^^^^^^^^^^^^^^^^^
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include
+Your Contribution in a Material, We may license the Contribution under
+any license, including copyleft, permissive, commercial, or
+proprietary licenses. As a condition on the exercise of this right, We
+agree to also license the Contribution under the terms of the license
+or licenses which We are using for the Material on the Submission
+Date.
+
+2.4 Moral Rights
+^^^^^^^^^^^^^^^^
+
+If moral rights apply to the Contribution, to the maximum extent
+permitted by law, You waive and agree not to assert such moral rights
+against Us or our successors in interest, or any of our licensees,
+either direct or indirect.
+
+2.5 Our Rights
+^^^^^^^^^^^^^^
+
+You acknowledge that We are not obligated to use Your Contribution as
+part of the Material and may decide to include any Contribution We
+consider appropriate.
+
+2.6 Reservation of Rights
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Any rights not expressly assigned or licensed under this section are
+expressly reserved by You.
+
+3. Agreement
+------------
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You own the Copyright and patent claims covering the Contribution
+    which are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of
+    rights which You have made to third parties, including Your
+    employer. If You are an employee, You have had Your employer
+    approve this Agreement or sign the Entity version of this
+    document. If You are less than eighteen years old, please have
+    Your parents or guardian sign the Agreement.
+
+(d) You have informed us in the relevant pull request(s) if You do not
+    own the Copyright to the entire Submission.
+
+4. Disclaimer
+-------------
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS
+PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES
+INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT
+THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS
+LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+5. Consequential Damage Waiver
+------------------------------
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL
+YOU OR US BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED
+SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL
+AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE
+LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE
+CLAIM IS BASED.
+
+6. Miscellaneous
+----------------
+
+**6.1** This Agreement will be governed by and construed in accordance
+with the laws of Ontario, Canada excluding its conflicts of law
+provisions. Under certain circumstances, the governing law in this
+section might be superseded by the United Nations Convention on
+Contracts for the International Sale of Goods ("UN Convention") and the
+parties intend to avoid the application of the UN Convention to this
+Agreement and, thus, exclude the application of the UN Convention in its
+entirety to this Agreement.
+
+**6.2** This Agreement sets out the entire agreement between You and
+Us for Your Contributions to Us and overrides all other agreements or
+understandings.
+
+**6.3** If You or We assign the rights or obligations received through
+this Agreement to a third party, as a condition of the assignment,
+that third party must agree in writing to abide by all the rights and
+obligations in the Agreement.
+
+**6.4** The failure of either party to require performance by the
+other party of any provision of this Agreement in one situation shall
+not affect the right of a party to require such performance at any
+time in the future. A waiver of performance under a provision in one
+situation shall not be considered a waiver of the performance of the
+provision in the future or a waiver of the provision in its entirety.
+
+**6.5** If any provision of this Agreement is found void and
+unenforceable, such provision will be replaced to the extent possible
+with a provision that comes closest to the meaning of the original
+provision and which is enforceable. The terms and conditions set forth
+in this Agreement shall apply notwithstanding any failure of essential
+purpose of this Agreement or any limited remedy to the maximum extent
+possible under law.

--- a/conf.py
+++ b/conf.py
@@ -4,11 +4,14 @@ from datetime import datetime
 
 import guzzle_sphinx_theme
 
-extensions = ["sphinx.ext.intersphinx",
-              "sphinx.ext.todo",
-              "sphinx.ext.mathjax",
-              "sphinx.ext.githubpages",
-              "guzzle_sphinx_theme"]
+extensions = [
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.todo",
+    "guzzle_sphinx_theme",
+]
 
 source_suffix = ".rst"
 master_doc = "index"

--- a/contributing.rst
+++ b/contributing.rst
@@ -7,3 +7,4 @@ Contributing to Nengo
 
    conduct
    style
+   git

--- a/contributing.rst
+++ b/contributing.rst
@@ -6,3 +6,4 @@ Contributing to Nengo
    :maxdepth: 2
 
    conduct
+   style

--- a/contributing.rst
+++ b/contributing.rst
@@ -8,3 +8,4 @@ Contributing to Nengo
    conduct
    style
    git
+   reviewing

--- a/contributing.rst
+++ b/contributing.rst
@@ -9,3 +9,4 @@ Contributing to Nengo
    style
    git
    reviewing
+   caa

--- a/git.rst
+++ b/git.rst
@@ -5,7 +5,7 @@ How we use git
 Development happens on `Github <https://github.com/nengo>`_.
 Feel free to fork any of our repositories and send a pull request!
 However, note that we ask contributors to sign
-:ref:`an assignment agreement <caa>`.
+:ref:`an assignment agreement <Nengo Contributor Assignment Agreement>`.
 
 Rules
 -----

--- a/git.rst
+++ b/git.rst
@@ -1,0 +1,51 @@
+**************
+How we use git
+**************
+
+Development happens on `Github <https://github.com/nengo>`_.
+Feel free to fork any of our repositories and send a pull request!
+However, note that we ask contributors to sign
+:ref:`an assignment agreement <caa>`.
+
+Rules
+-----
+
+We use a pretty strict ``git`` workflow
+to ensure that the history of the ``master`` branch
+is clean and readable.
+
+1. Every commit in the ``master`` branch should pass testing,
+   including static checks like ``flake8`` and ``pylint``.
+2. Commit messages must follow guidelines (see below).
+3. Developers should never edit code on the ``master`` branch.
+   When changing code, create a new topic branch for your contribution.
+   When your branch is ready to be reviewed,
+   push it to Github and create a pull request.
+4. Pull requests must be reviewed by at least two people before merging.
+   There may be a fair bit of back and forth before
+   the pull request is accepted.
+5. Pull requests cannot be merged by the creator of the pull request.
+6. Only `maintainers <https://github.com/orgs/nengo/teams>`_,
+   can merge pull requests to ensure that the history remains clean.
+
+Commit messages
+---------------
+
+We use several advanced ``git`` features that
+rely on well-formed commit messages.
+Commit messages should fit the following template.
+
+.. code-block:: none
+
+   Capitalized, short (50 chars or less) summary
+
+   More detailed body text, if necessary.  Wrap it to around 72 characters.
+   The blank line separating the summary from the body is critical.
+
+   Paragraphs must be separated by a blank line.
+
+   - Bullet points are okay, too.
+   - Typically a hyphen or asterisk is used for the bullet, followed by
+     single space, with blank lines before and after the list.
+   - Use a hanging indent if the bullet point is longer than a
+     single line (like in this point).

--- a/index.rst
+++ b/index.rst
@@ -53,3 +53,4 @@ for details).
    :maxdepth: 2
 
    contributing
+   maintainers

--- a/maintainers.rst
+++ b/maintainers.rst
@@ -1,0 +1,8 @@
+****************
+Maintainer guide
+****************
+
+.. toctree::
+   :maxdepth: 2
+
+   releasing

--- a/releasing.rst
+++ b/releasing.rst
@@ -1,0 +1,164 @@
+*********************
+Making Nengo releases
+*********************
+
+While we endeavour to automate as much as
+the below as possible,
+it's nonetheless important to know
+how a Nengo release works.
+There are three stages to this process,
+which will result in at least
+two ``git`` commits and one ``git`` tag.
+
+Stage 1: Preparing
+==================
+
+Before making a release,
+we do a few things to prepare:
+
+1. Ensure ``master`` is up-to-date by doing ``git pull``.
+
+2. Run `check-manifest <https://pypi.python.org/pypi/check-manifest>`_
+   to ensure that all files are included in the release.
+
+3. Run all tests to ensure they pass on Python 2 and 3,
+   including slow tests that are normally skipped.
+
+   .. code:: bash
+
+      py.test --pyargs nengo --plots --analytics --logs --slow
+
+4. Review all of the plots generated from running the tests
+   for abnormalities or unclear figures.
+
+5. Run all tests with the Nengo OCL backend.
+
+   .. code:: bash
+
+      py.test --pyargs nengo --plots --simulator nengo_ocl.Simulator
+
+   If any tests fail, attempt to fix them by changing Nengo.
+   If they cannot be fixed in Nengo, then
+   `file an issue <https://github.com/nengo/nengo_ocl/issues>`_.
+
+6. Build the documentation and review all of the rendered
+   examples for abnormalities or unclear figures.
+
+7. Commit all changes from the above steps before moving on to the next stage.
+
+.. todo::
+
+   Currently we do not run slow tests on all platforms (Windows, Mac OS X, Linux
+   with 32-bit and 64-bit versions of Python 2.7, 3.3, 3.4, and 3.5).
+   Doing so is difficult without dedicated hardware.
+
+Note that any possibly controversial fixes done as a result of
+Stage 1 should be done through the normal process of making
+a pull request and going through review.
+However, from Stage 2 onward, the work is done directly
+on the ``master`` branch.
+It can therefore result in bad things,
+so proceed with caution!
+
+Stage 2: Releasing
+==================
+
+Once everything is prepared, we're ready to do the release.
+It should be okay to work in the same directory that you
+do development, but if you want to be extra safe,
+you can do a fresh clone of Nengo into a separate directory.
+
+1. Change the version information in ``nengo/version.py``.
+   See that file for details.
+
+2. Set the release date in the changelog (``CHANGES.rst``).
+
+3. ``git add`` the changes above and make a release commit with
+
+   .. code:: bash
+
+      git commit -m "Release version $(python -c 'import nengo; print(nengo.__version__)')"
+
+4. Review ``git log`` to ensure that the version number is correct; if not,
+   then something went wrong with the previous steps.
+   Correct these mistakes and amend the release commit accordingly.
+
+5. Tag the release commit with the version number; i.e.,
+
+   .. code:: bash
+
+      git tag -a v$(python -c 'import nengo; print(nengo.__version__)')
+
+   We use annotated tags for the authorship information;
+   if you wish to provide a message with information about the release,
+   feel free, but it is not necessary.
+
+6. ``git push origin master`` and ``git push origin [tagname]``.
+
+7. Create a release package and upload it to PyPI with
+
+   .. code:: bash
+
+      python setup.py sdist upload
+
+8. Build and upload the documentation with
+
+   .. code:: bash
+
+      python setup.py upload_sphinx
+
+Stage 3: Cleaning up
+====================
+
+Nengo's now released!
+We need to do a few last things to
+put Nengo back in a development state.
+
+1. Change the version information in ``nengo/version.py``.
+   See that file for details.
+
+2. Make a new changelog section in ``CHANGES.rst``
+   in order to collect changes for the next release.
+
+3. ``git add`` the changes above and make a commit describing
+   the current state of the repository and commit with
+
+   .. code:: bash
+
+      git commit -m "Starting development of vX.Y.Z"
+
+4. ``git push origin master``
+
+Stage 4: Announcing
+===================
+
+Now we have to let the world know about the new release.
+We do this in two ways for each release.
+
+1. Copy the changelog into the tag details on the
+   `Github release tab <https://github.com/nengo/nengo/releases>`_.
+   Note that the changelog is in reStructuredText,
+   while Github expects Markdown.
+   Use `Pandoc <http://pandoc.org/try/>`_ or a similar tool
+   to convert between the two formats.
+
+2. Write a release announcement.
+   Generally, it's easiest to start from
+   the last release announcement
+   and change it to make sense with the current release
+   so that the overall template of each announcement is similar.
+
+All release announcements should be posted
+on the `forum <https://forum.nengo.ai/c/general/announcements>`_
+and on the `ABR website <http://appliedbrainresearch.com/>`_.
+Links to the announcements should be posted
+on `Twitter <https://twitter.com/abr_inc>`_.
+
+For major release
+(e.g., the first release of a new backend,
+or a milestone release like 1.0),
+consider writing a more general and
+elaborate announcement and posting it to wider-reaching venues, such as
+`the comp-neuro mailing list <http://www.tnb.ua.ac.be/mailman/listinfo/comp-neuro>`_,
+`Planet SciPy <https://planet.scipy.org/>`_,
+and `Planet Python <http://planetpython.org/>`_.

--- a/reviewing.rst
+++ b/reviewing.rst
@@ -1,0 +1,306 @@
+***********************
+Reviewing pull requests
+***********************
+
+Nengo is developed by a community of developers
+with varying backgrounds in software development,
+neuroscience, machine learning, and many other areas.
+We rely on each other to review our work
+and ensure that our code is
+correct, consistent, and documented.
+Every Nengo pull request (PR) is reviewed by two people.
+Any Nengo developer can do a review,
+and anyone who has had a PR accepted into Nengo
+is a Nengo developer.
+
+Here are the steps developers should take when doing a review.
+
+1. Assign yourself to the PR to let others know you're reviewing it.
+2. Familiarize yourself with the part of the codebase that the PR changes.
+3. Read through the code changes and commit messages.
+4. Test the PR branch.
+5. Make inline comments.
+6. Make commits for proposed changes.
+7. Make a final decision on the PR.
+8. Change labels accordingly.
+
+In all of these steps
+we expect reviewers to be respectful, kind,
+and to focus on the code and not the author of the code.
+We all need high quality feedback to grow as developers,
+but are demotivated when comments feel personal.
+Keep in mind how your comments may be interpreted
+by the PR author, especially if the PR author
+is a new developer.
+
+Reading code diffs
+==================
+
+Reading through code diffs is a skill that takes a fair bit
+of practice -- but the only way to practice is by doing it!
+A useful exercise when starting out is to read the code diffs
+for many PRs even if you don't plan to review that PR.
+
+There are two ways to read code diffs.
+
+1. Read the diff of the entire PR.
+   In Github, this is found in the "Files changed" tab of the PR.
+   This works best for quick and average PRs
+   that change only one area of the codebase.
+2. Read the diff commit-by-commit.
+   In Github, this is found in the "Commits" tabs of the PR.
+   There are links in each commit to the previous and next commits
+   to make reading the diff easier.
+   This works best for lengthy PRs,
+   and is made easier when the PR author keeps related changes
+   in the same commit.
+
+In general, if looking at the diff of the entire PR is difficult,
+then switch to reading the diff commit-by-commit.
+If reading the diff commit-by-commit is difficult,
+then ask the PR author to make the history of the PR easier to read.
+
+In reading through the code diff,
+you should be sensitive to both what the code does,
+and how it does it.
+If you think you can express the same logic
+with less code and/or in a more obvious way,
+then please propose the change as described below.
+
+Testing the PR branch
+=====================
+
+In general, we rely on the test suite to ensure that
+the code introduced in a PR is correct
+(i.e., works as intended, doesn't break people's models).
+For new features, the PR should include tests
+to ensure the new code is correct.
+For bugfixes, the PR should include a test that fails
+without the changes in the PR.
+For refactorings, optimizations, and other improvements
+that do not fix bugs or add new features,
+existing tests should cover the new code.
+In all of these cases,
+run the appropriate parts of the test suite locally
+to ensure that the tests pass.
+Pytest's  ``-k`` flag comes in handy for running
+only specific tests.
+
+If the change does not have tests,
+follow the manual testing steps in the PR description.
+If no manual testing steps are specified,
+then ask the PR author for testing steps.
+
+Making inline comments
+======================
+
+Github allows you to make comments
+on specific lines of a diff.
+You can do this in both ways of reading through diffs
+described above (all at once, or commit-by-commit).
+
+Inline commits should be used for questions and minor changes only.
+Good uses of inline comments include:
+
+- Asking for clarification of what some small chunk of code does.
+- Asking for the reasoning behind some code choice.
+- Pointing out a typo.
+- Pointing out a possible style improvement.
+- Making a note of something you will change in a commit.
+
+Please be explicit about your expectations
+of what will happen in response to your comment.
+If you're asking a question,
+then it is clear that the PR author should respond.
+If you're pointing out an issue
+that you plan to fix later with a commit,
+say that in your comment so that the PR author
+doesn't make that change in the meantime.
+
+A bad use of an inline comment is to ask for
+a significant change to the PR.
+These comments tend to be
+frustrating for PR authors to respond to
+and end up prolonging the review process.
+For significant changes, instead make a commit.
+
+Inline comments should not block the merging of a PR.
+The maintainer merging the PR will make the typo / style fixes
+they deem appropriate during the merge
+if the PR author doesn't get around to fixing them.
+If the discussion raises a new issue or feature request,
+make a new issue to track that so that it doesn't
+block PR progress.
+
+Making commits
+==============
+
+Instead of asking the PR author for changes,
+we prefer reviewers make commits
+to propose changes to a PR.
+Commits allow the reviewer to propose explicit
+changes that the PR author can say yes or no to,
+rather than placing the burden on the PR author
+and allowing for miscommunication.
+
+In most cases, PRs are made from a feature branch
+to master in the same repository,
+in which case you can push commits
+to the feature branch directly.
+If the PR comes from a fork,
+you may have to make a PR
+on the feature branch in their repo.
+
+There are four types of commits that reviewers
+can add, depending on the type of change proposed.
+
+1. ``fixup`` commits should be used for minor changes
+   like style fixes, moving code from one location to another,
+   and fixing small bugs.
+   In the end, your ``fixup`` commit will not appear in
+   the history of the ``master`` branch.
+
+   To make a ``fixup`` commit, first make the desired changes
+   and ``git add`` them. When making the commit, do
+   ``git commit --fixup <commit hash>`` where the commit hash
+   corresponds to the commit that your ``fixup`` commit modifies.
+
+   ``fixup`` commits are so named because
+   the maintainer will ``fixup`` those commits into
+   the appropriate part of the PR branch's history
+   before merging that branch into ``master``.
+
+2. ``squash`` commits should be used for minor changes
+   that require some explanation.
+   In the end, your ``squash`` commit will not appear in
+   the history of the ``master`` branch,
+   except in one or more commit messages.
+
+   To make a ``squash`` commit, first make the desired changes
+   and ``git add`` them. When making the commit, do
+   ``git commit --squash <commit hash>`` where the commit hash
+   corresponds to the commit that your ``squash`` commit modifies.
+   Unlike with the ``--fixup`` option, git will now prompt you
+   to enter a message to explain what your ``squash`` commit does.
+
+   ``squash`` commits are so named because
+   the maintainer will ``squash`` those commits into
+   the appropriate part of the PR branch's history
+   before merging that branch into ``master``.
+   Since ``squash`` commits contain a commit message,
+   maintainers will review the message when merging
+   that branch into ``master`` and incorporate it in
+   the squashed commit message if appropriate.
+
+3. Normal commits should be used for major changes
+   that should be reflected in the ``master`` history.
+   A good rule of thumb to determine if your change
+   should be in a normal commit
+   is if you would be upset if that work was attributed
+   to someone else, as would happen for a ``fixup``
+   or ``squash`` commit.
+   If you're not sure,
+   feel free to make a normal commit anyway,
+   as the maintainer may choose to squash it regardless.
+
+4. Commits in a separate branch should be used for
+   large and possibly controversial changes.
+   This typically happens when you end up essentially
+   reimplementing all of the content in the PR
+   but in a different way.
+   If you find that after your changes very little
+   of the original PR's changes remain,
+   then consider making your changes in a separate branch
+   and then making a PR from your branch to the original PR branch.
+
+It is important to note that none of the options listed above
+require rewriting the history of the PR branch.
+All commits should be made at the end of the branch
+so that regular pushes (not force pushes) can be used.
+If the PR branch is getting out of date
+and you wish to rebase the branch,
+ensure that no one else is assigned to the PR,
+assign yourself, and add a comment
+once you have force-pushed the rebased branch.
+
+Making a final decision
+=======================
+
+In order to shorten the amount of back-and-forth
+in a given PR,
+we ask that reviewers make a decision about the PR
+and post that decision as a comment on the PR
+after making inline comments and commits.
+
+Your decision should be one of the following:
+
+1. This PR is good to merge, or will be good to merge with my changes.
+2. This PR could be good to merge, but it requires significant changes
+   that I am working on.
+3. This PR could be good to merge, but it requires significant changes.
+4. This PR is not appropriate for this project.
+
+For the second and third options,
+be mindful of people's time commitments.
+If the reviewer or PR author is not able
+to make the appropriate changes within 60 days,
+add the "revise and resubmit" label to the PR,
+make a comment on the PR, and close it.
+PRs can be reopened, so when that person
+gets time to work on it, they can either reopen
+the PR and add new commits,
+or make a new PR with the revised contribution.
+
+The fourth option should not be taken lightly,
+but is necessary for the long-term success of a project.
+A PR left open too long is worse than a PR that is
+closed with a good reason and a clear next step.
+Never close a pull request without giving a reason
+and a next step for the PR author.
+
+Here are some good reasons for closing a PR,
+with next steps.
+
+1. This PR adds something that we do not think will be
+   used frequently, or duplicates existing functionality.
+   Please consider submitting this PR to
+   `nengo_extras <https://github.com/nengo/nengo_extras>`_,
+   another suitable place,
+   or make a separate repository for it and let us know
+   about that repository.
+2. This PR has some unresolved issues that have not been addressed
+   in a reasonable amount of time.
+   We would still like the changes in this PR,
+   so please address our comments and make a new PR
+   with those changes included.
+3. This PR causes tests to fail, and it's not clear
+   how to make the tests pass again.
+   Please get the tests to pass and resubmit this PR.
+   We are happy to help if parts of the code aren't clear!
+
+This is by no means an exhaustive list,
+and PRs adding to this list are appreciated!
+For a longer discussion about
+the art of closing PRs,
+see `this blog post <https://blog.jessfraz.com/post/the-art-of-closing/>`_.
+
+Changing labels
+===============
+
+We use labels to keep track of the review status of each PR.
+Here are the conventions that we use.
+
+1. When a PR is created and ready for review,
+   the author or a maintainer will add the ``needs review`` label.
+2. If the first reviewer believes the PR is good to merge,
+   they remove the ``needs review`` label and add the
+   ``needs second review`` label.
+3. If the second reviewer also believes the PR is good to merge,
+   they remove the ``needs second review`` label and add the
+   ``reviewed`` label.
+4. If any reviewer believes the PR has unresolved issues,
+   they remove the ``needs review`` or ``needs second review``
+   label and add the ``needs changes`` label.
+5. If a PR with the ``needs changes`` label has not changed
+   in 60 days, add the ``revise and resubmit`` label
+   before closing the PR.

--- a/style.rst
+++ b/style.rst
@@ -1,0 +1,85 @@
+**********
+Code style
+**********
+
+Python
+======
+
+We adhere to
+`PEP8 <http://www.python.org/dev/peps/pep-0008/>`_,
+and use ``flake8`` to automatically check for adherence on all commits.
+If you want to run this yourself,
+then ``pip install flake8`` and run
+
+.. code-block:: bash
+
+   flake8 nengo
+
+in the ``nengo`` repository you cloned.
+
+Class member order
+------------------
+
+In general, we stick to the following order for members of Python classes.
+
+1. Class-level member variables (e.g., ``nengo.Ensemble.probeable``).
+2. Parameters (i.e., classes derived from `nengo.params.Parameter`)
+   with the parameters in ``__init__`` going first in that order,
+   then parameters that don't appear in ``__init__`` in alphabetical order.
+   All these parameters should appear in the Parameters section of the docstring
+   in the same order.
+3. ``__init__``
+4. Other special (``__x__``) methods in alphabetical order,
+   except when a grouping is more natural
+   (e.g., ``__getstate__`` and ``__setstate__``).
+5. ``@property`` properties in alphabetical order.
+6. ``@staticmethod`` methods in alphabetical order.
+7. ``@classmethod`` methods in alphabetical order.
+8. Methods in alphabetical order.
+
+"Hidden" versions of the above (i.e., anything starting with an underscore)
+should either be placed right after they're first used,
+or at the end of the class.
+Also consider converting long hidden methods
+to functions placed in the ``nengo.utils`` module.
+
+.. note:: These are guidelines that should be used in general,
+          not strict rules.
+          If there is a good reason to group differently,
+          then feel free to do so, but please explain
+          your reasoning in code comments or commit notes.
+
+Docstrings
+----------
+
+We use ``numpydoc`` and
+`NumPy's guidelines for docstrings
+<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_,
+as they are readable in plain text and when rendered with Sphinx.
+
+We use the default role of ``obj`` in documentation,
+so any strings placed in backticks in docstrings
+will be cross-referenced properly if they
+unambiguously refer to something in the Nengo documentation.
+See `Cross-referencing syntax
+<http://www.sphinx-doc.org/en/stable/markup/inline.html#cross-referencing-syntax>`_
+and the `Python domain
+<http://www.sphinx-doc.org/en/stable/domains.html>`_
+for more information.
+
+A few additional conventions that we have settled on:
+
+1. Default values for parameters should be specified next to the type.
+   For example::
+
+     radius : float, optional (Default: 1.0)
+         The representational radius of the ensemble.
+
+2. Types should not be cross-referenced in the parameter list,
+   but can be cross-referenced in the description of that parameter.
+   For example::
+
+     solver : Solver
+         A `.Solver` used in the build process.
+
+.. todo:: JS, TS, CSS, HTML, etc


### PR DESCRIPTION
A lot of the dev docs that we have in Nengo should apply to all of our projects; this PR pulls in those documents unchanged. I'll be making PRs changing these docs as a result of recent discussion shortly, but it's good to have the originals in the history first so we can discuss the diffs.

I've made [Nengo#1251](https://github.com/nengo/nengo/pull/1251) to remove the docs. Any discussion for this can happen there; I'm going to merge this immediately so that the links over there are live. If the corresponding Nengo PR is rejected for whatever reason, then we can just roll this back, no biggie!