### PR TITLE
Include README in built documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-*******************
-Nengo documentation
-*******************
+*********************
+About nengo.github.io
+*********************
 
 This repository is home to documentation
 of the whole Nengo ecosystem.
@@ -8,14 +8,21 @@ of the whole Nengo ecosystem.
 How to contribute
 =================
 
-Documentation is written in
-`restructedText <http://docutils.sourceforge.net/rst.html>`_,
-built with `Sphinx <http://www.sphinx-doc.org/>`_
-automatically using `TravisCI <https://travis-ci.org/>`_
-and hosted with `Github pages <https://pages.github.com/>`_.
+This documentation is
+
+- hosted at `nengo/nengo.github.io <https://github.com/nengo/nengo.github.io>`_
+- written in `restructedText <http://docutils.sourceforge.net/rst.html>`_
+- built with `Sphinx <http://www.sphinx-doc.org/>`_
+- deployed automatically using `TravisCI <https://travis-ci.org/>`_
+- served with `Github pages <https://pages.github.com/>`_
 
 If you want to build the site locally to verify your changes, do
 
 .. code:: bash
 
    sphinx-build . _build
+
+As with all Nengo projects,
+issues and pull requests are welcome!
+Questions and comments can be posted on
+the `Nengo forum <https://forum.nengo.ai/>`_.

--- a/index.rst
+++ b/index.rst
@@ -54,3 +54,4 @@ for details).
 
    contributing
    maintainers
+   README


### PR DESCRIPTION
This fixes a Sphinx warning, and I think makes sense in the context of the documentation. If desired, we can take it out and fix the warning another way.