### PR TITLE
Add a page for the Nengo team

### DIFF
--- a/_records/README.rst
+++ b/_records/README.rst
@@ -1,0 +1,8 @@
+*************
+Nengo records
+*************
+
+This directory contains files kept around for record keeping purposes.
+These files are not rendered to HTML,
+but they are still available in the public repository,
+so please don't put any sensitive information like passwords here.

--- a/_records/caa.rst
+++ b/_records/caa.rst
@@ -1,0 +1,61 @@
+**************
+CAA signatures
+**************
+
+The Nengo CAA is typically signed digitally by making a commit
+to a Nengo repository (including this one).
+Below, we record all of the digital signatures for posterity.
+
+- `Aaron Voelker
+  <https://github.com/nengo/nengo_gui/commit/dd158e43296e3104a409e893db1caba2ec463646>`_
+- `Andreas Stöckel
+  <https://github.com/nengo/nengo_gui/commit/05eb36ddb10fba31994b4de95d0548d9a8ee2030>`_
+- `Andrew Mundy
+  <https://github.com/nengo/nengo/commit/1ac5f7b4ec1e5f709b0349c99b4d766c5a91fc7a>`_
+- `Ben Morcos
+  <https://github.com/nengo/nengo/commit/588ba3d419a6cc5602f65895b0a8d1a55eb395f3>`_
+- `Brent Komer
+  <https://github.com/nengo/nengo_gui/commit/2698ef20ccfa09194c7d88e4c7179005e8e6b38d>`_
+- `Christopher Chan
+  <https://github.com/nengo/nengo_gui/commit/f4227721bc6338176f558be616778e2434808a3f>`_
+- `Eric Hunsberger
+  <https://github.com/nengo/nengo_gui/commit/7def1d51b1d36970a1ae07ada7afdcc0d842e99a>`_
+- `Ivana Kajić
+  <https://github.com/nengo/nengo/commit/5fcd7b18aa9496e5c47c38c6408430cd9f68a720>`_
+- `Jan Gosmann
+  <https://github.com/nengo/nengo/commit/4f58e4c1578ab020dd74806862db18782d53e36e>`_
+- `Ménélik Vero
+  <https://github.com/nengo/nengo_ocl/commit/a8f728e0823aa300577a311e6f5a434b01bb4398>`_
+- `Petrut Bogdan
+  <https://github.com/nengo/nengo_gui/commit/23e1c54707f887a4aaf38a7b3e2dc52fde158d95>`_
+- `Rees Simmons
+  <https://github.com/nengo/nengo_gui/commit/54e46d1fd25f486f5c67cfbadc14f43048dcc8ac>`_
+- `Sean Aubin
+  <https://github.com/nengo/nengo/commit/a75e67411ec836d82efcba2591cd88727bcc614d>`_
+- `Shaun Ren
+  <https://github.com/nengo/nengo_ocl/commit/33268519a632735a31bd8df4a737533bff8c9f28>`_
+- `Sugandha Sharma
+  <https://github.com/nengo/nengo/commit/fe5342047b63bf39e59fa1406e017f0a770b5769>`_
+- `Travis DeWolf
+  <https://github.com/nengo/nengo_gui/commit/7ebcac76170a014ad56a1d920b761f9eb11afa66>`_
+- `Xuan Choo
+  <https://github.com/nengo/nengo_gui/commit/b73e651c2eee7d78d718a8fe139edd8fd6e58c80>`_
+- `Youssef Zaky
+  <https://github.com/nengo/nengo/commit/5739f262d325165cfc13f41526dabed8795c7abf>`_
+
+Additionally,
+the following people have signed agreements
+analogous to the CAA on paper.
+The signed agreements are available upon request.
+
+- Bryan Tripp
+- Chris Eliasmith
+- Daniel Rasmussen
+- Eric Crawford
+- James Bergstra
+- Oliver Trujillo
+- Peter Blouw
+- Peter Suma
+- Terry Stewart
+- Trevor Bekolay
+- Ziying Zhang

--- a/caa.rst
+++ b/caa.rst
@@ -13,8 +13,8 @@ Applied Brain Research ("We" or "Us").
 This contributor agreement (the "Agreement") documents the rights
 granted by contributors to Us.
 
-By adding your name to the CONTRIBUTORS.rst file at
-<https://github.com/nengo/nengo/blob/master/CONTRIBUTORS.rst>
+By adding your name to the ``people.rst`` file at
+<https://github.com/nengo/nengo.github.io/blob/master/people.rst>
 you are agreeing to be bound by the Agreement in full.
 
 You agree to inform Us in the relevant pull request(s) if You do not own

--- a/conf.py
+++ b/conf.py
@@ -20,7 +20,7 @@ extensions = [
 suppress_warnings = ['image.nonlocal_uri']
 source_suffix = ".rst"
 master_doc = "index"
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "_records/*.rst"]
 suppress_warnings = ['image.nonlocal_uri']
 
 project = "Nengo"

--- a/index.rst
+++ b/index.rst
@@ -56,4 +56,5 @@ for details).
    users
    contributing
    maintainers
+   people
    README

--- a/people.rst
+++ b/people.rst
@@ -1,0 +1,43 @@
+******
+People
+******
+
+Nengo is made by a team of awesome people.
+Thanks to everyone who has made a contribution!
+
+The alphabetically sorted list below
+includes everyone who has contributed to a Nengo-managed project;
+not everyone on this list
+`is still active <https://github.com/orgs/nengo/teams/active-contributors>`_.
+If you want to contact someone about a Nengo project,
+please contact the :ref:`project maintainer <Projects>`.
+
+- Aaron Voelker <arvoelke@gmail.com>
+- Andreas Stöckel <andreas.stoeckel@gmail.com>
+- Andrew Mundy <andrew.mundy@ieee.org>
+- Ben Morcos <morcos.ben@gmail.com>
+- Brent Komer <brent.komer@gmail.com>
+- Bryan Tripp <bptripp@uwaterloo.ca>
+- Chris Eliasmith <celiasmith@uwaterloo.ca>
+- Christopher Chan <c88chan@uwaterloo.ca>
+- Daniel Rasmussen <dhrsmss@gmail.com>
+- Eric Crawford <eric.crawford@mail.mcgill.ca>
+- Eric Hunsberger <erichuns@gmail.com>
+- Ivana Kajić <ivana.kajic@gmail.com>
+- James Bergstra <james.bergstra@gmail.com>
+- Jan Gosmann <jan@hyper-world.de>
+- Ménélik Vero <menelik.vero@tum.de>
+- Oliver Trujillo <olivertgp@hotmail.com>
+- Peter Blouw <pblouw@uwaterloo.ca>
+- Peter Suma <psuma@waterloo.ca>
+- Petrut Bogdan <petrutantoniu8@gmail.com>
+- Rees Simmons <rsimmons@uwaterloo.ca>
+- Sean Aubin <seanaubin@gmail.com>
+- Shaun Ren <shaun.ren@linux.com>
+- Sugandha Sharma <sugandha974@gmail.com>
+- Terry Stewart <terry.stewart@gmail.com>
+- Travis DeWolf <travis.dewolf@gmail.com>
+- Trevor Bekolay <tbekolay@gmail.com>
+- Xuan Choo <xchoo.mainframe@gmail.com>
+- Youssef Zaky <youssefzaky@gmail.com>
+- Ziying Zhang <zy8zhang@uwaterloo.ca>


### PR DESCRIPTION
This is essentially the union of all `CONTRIBUTORS.rst` pages. By keeping it in one spot, it means that someone contributing to Nengo doesn't have to also sign the contributor page for Nengo GUI, SPA, OCL, etc. before making a contribution.

This PR also adds a directory for keeping records that won't be rendered to HTML on nengo.github.io; however, since this is a public repo, they're still publicly available, so keep that in mind before adding sensitive things to that directory.

Note that this is based on #15 as the projects page is linked. That PR should be merged first.

A few discussion points:

- Should this list replace the `CONTRIBUTORS.rst` pages in individual projects? One the one hand removing those pages would relieve a little bit of burden on each project's maintainer. On the other hand, keeping lists of contributors to specific projects can be useful, though in most cases the list is only useful for morale (which `people.rst` could do instead) and contacting the maintainer (which isn't really accomplished with `CONTRIBUTORS.rst`).
- A good portion of what would be CAA signatures were done on paper. We have scanned PDF copies of those, but is it necessary to upload these somewhere or should we mark these as "available elsewhere"?
