### PR TITLE
Revamp reviewing guide

### DIFF
--- a/reviewing.rst
+++ b/reviewing.rst
@@ -2,140 +2,144 @@
 Reviewer guide
 **************
 
-Nengo is developed by a community of developers
-with varying backgrounds in software development,
+The Nengo team has
+varying backgrounds in software development,
 neuroscience, machine learning, and many other areas.
 We rely on each other to review our work
 and ensure that our code is
 correct, consistent, and documented.
-Every Nengo pull request (PR) is reviewed by two people.
-Any Nengo developer can do a review,
-and anyone who has had a PR accepted into Nengo
-is a Nengo developer.
+Every pull request (PR) is reviewed by at least one person,
+though usually two.
 
-Here are the steps developers should take when doing a review.
+Guidelines
+==========
 
-1. Assign yourself to the PR to let others know you're reviewing it.
-2. Familiarize yourself with the part of the codebase that the PR changes.
-3. Read through the code changes and commit messages.
-4. Test the PR branch.
-5. Make inline comments.
-6. Make commits for proposed changes.
-7. Make a final decision on the PR.
-8. Change labels accordingly.
-
-In all of these steps
-we expect reviewers to be respectful, kind,
+We expect reviewers to be respectful, kind,
 and to focus on the code and not the author of the code.
-We all need high quality feedback to grow as developers,
-but are demotivated when comments feel personal.
-Keep in mind how your comments may be interpreted
-by the PR author, especially if the PR author
-is a new developer.
+Even when we mean well,
+words on a screen don't always convey the right tone.
+We've found these guidelines to be helpful
+for keeping the tone positive.
 
-Reading code diffs
-==================
+- Accept that many programming decisions are opinions.
+  Discuss tradeoffs, which you prefer, and reach a resolution quickly.
+- Ask questions; don't make demands.
+  ("What do you think about naming this ``n_neurons``?")
+- Ask for clarification. ("I don't understand this line. Can you clarify?")
+- Avoid selective ownership of code. ("mine", "not mine", "yours")
+- Avoid using terms that could be seen as referring to personal traits
+  ("dumb", "stupid").
+  Assume everyone is attractive, intelligent, and well-meaning.
+- Be explicit. People may not understand your intentions.
+- Be humble. ("I'm not sure---let's look it up.")
+- Don't use hyperbole ("always", "never", "endlessly", "nothing").
+- Be careful about the use of sarcasm.
+  What seems like good-natured ribbing to you
+  and a long-time colleague might come off
+  as mean and unwelcoming to a person new to the project.
+- Move to one-on-one chats or video calls
+  if there are too many "I didn't understand"
+  or "Alternative solution:" comments.
+  Post a follow-up comment summarizing the offline discussion.
 
-Reading through code diffs is a skill that takes a fair bit
-of practice -- but the only way to practice is by doing it!
-A useful exercise when starting out is to read the code diffs
-for many PRs even if you don't plan to review that PR.
+Becoming a reviewer
+===================
+
+Any Nengo contributor can volunteer to be a reviewer.
+Head to the `list of Nengo teams <https://github.com/orgs/nengo/teams>`_
+and request to join
+the `Active reviewers team <https://github.com/orgs/nengo/teams/active-reviewers>`_.
+If you've contributed to a Nengo project,
+then its maintainer will assign you reviews
+based on your contributions thus far.
+You will be assigned
+at most two reviews concurrently.
+
+If you have any concerns or preferences,
+please contact a :ref:`project maintainer <Projects>`!
+
+Reviewing a pull request
+========================
+
+1. Read through the code changes and commit messages.
+2. Test that the PR does what it claims to do.
+3. Make commits to propose changes.
+4. Submit a Github review.
+
+If any of the above steps are unclear, read on.
+
+1. Reading code changes
+-----------------------
+
+Reading through code changes (often called diffs)
+is a skill that takes a fair bit
+of practice---but the only way to practice is by doing it!
+A useful exercise when starting out is to read diffs
+for new PRs even if you aren't assigned to review that PR.
 
 There are two ways to read code diffs.
 
 1. Read the diff of the entire PR.
+
    In Github, this is found in the "Files changed" tab of the PR.
-   This works best for quick and average PRs
+   This works best for quick and average length PRs
    that change only one area of the codebase.
+
 2. Read the diff commit-by-commit.
+
    In Github, this is found in the "Commits" tabs of the PR.
    There are links in each commit to the previous and next commits
    to make reading the diff easier.
    This works best for lengthy PRs,
-   and is made easier when the PR author keeps related changes
-   in the same commit.
+   or average length PRs that change multiple areas
+   of the codebase.
 
-In general, if looking at the diff of the entire PR is difficult,
-then switch to reading the diff commit-by-commit.
+In general, start by looking at the diff of the entire PR.
+If it's difficult to read,
+switch to reading the diff commit-by-commit.
 If reading the diff commit-by-commit is difficult,
 then ask the PR author to make the history of the PR easier to read.
 
-In reading through the code diff,
-you should be sensitive to both what the code does,
-and how it does it.
-If you think you can express the same logic
-with less code and/or in a more obvious way,
-then please propose the change as described below.
+In reading through the code diff:
 
-Testing the PR branch
-=====================
+- Try to be thorough to reduce the number of iterations.
+- Seek to understand the author's perspective.
+- Identify ways to simplify the code while still solving the problem.
+- If you don't understand a piece of code, say so.
+  There's a good chance someone else would be confused by it as well.
 
-In general, we rely on the test suite to ensure that
-the code introduced in a PR is correct
-(i.e., works as intended, doesn't break people's models).
-For new features, the PR should include tests
-to ensure the new code is correct.
-For bugfixes, the PR should include a test that fails
-without the changes in the PR.
-For refactorings, optimizations, and other improvements
-that do not fix bugs or add new features,
-existing tests should cover the new code.
+2. Testing the PR
+-----------------
+
+In general, we rely on automated testing to ensure that
+the code introduced in a PR works as advertised.
+
+- For new features, the PR should include tests
+  to ensure the new code is correct.
+- For bugfixes, the PR should include a test that fails
+  without the changes in the PR.
+- For refactorings, optimizations, and other improvements
+  that do not fix bugs or add new features,
+  existing tests should cover the new code.
+
 In all of these cases,
 run the appropriate parts of the test suite locally
 to ensure that the tests pass.
-Pytest's  ``-k`` flag comes in handy for running
-only specific tests.
 
-If the change does not have tests,
-follow the manual testing steps in the PR description.
-If no manual testing steps are specified,
-then ask the PR author for testing steps.
+If the PR does not include tests,
+we encourage you to add those tests
+as a part of your review.
+Adding tests helps you understand the PR better,
+and helps everyone in the project
+by ensuring the codebase works as expected.
+However, if you do not have time to write tests,
+requesting that they be added
+is a valid resolution to a review.
 
-Making inline comments
-======================
+3. Making commits to propose changes
+------------------------------------
 
-Github allows you to make comments
-on specific lines of a diff.
-You can do this in both ways of reading through diffs
-described above (all at once, or commit-by-commit).
-
-Inline commits should be used for questions and minor changes only.
-Good uses of inline comments include:
-
-- Asking for clarification of what some small chunk of code does.
-- Asking for the reasoning behind some code choice.
-- Pointing out a typo.
-- Pointing out a possible style improvement.
-- Making a note of something you will change in a commit.
-
-Please be explicit about your expectations
-of what will happen in response to your comment.
-If you're asking a question,
-then it is clear that the PR author should respond.
-If you're pointing out an issue
-that you plan to fix later with a commit,
-say that in your comment so that the PR author
-doesn't make that change in the meantime.
-
-A bad use of an inline comment is to ask for
-a significant change to the PR.
-These comments tend to be
-frustrating for PR authors to respond to
-and end up prolonging the review process.
-For significant changes, instead make a commit.
-
-Inline comments should not block the merging of a PR.
-The maintainer merging the PR will make the typo / style fixes
-they deem appropriate during the merge
-if the PR author doesn't get around to fixing them.
-If the discussion raises a new issue or feature request,
-make a new issue to track that so that it doesn't
-block PR progress.
-
-Making commits
-==============
-
-Instead of asking the PR author for changes,
+Instead of asking the PR author to make changes,
 we prefer reviewers make commits
 to propose changes to a PR.
 Commits allow the reviewer to propose explicit
@@ -143,16 +147,8 @@ changes that the PR author can say yes or no to,
 rather than placing the burden on the PR author
 and allowing for miscommunication.
 
-In most cases, PRs are made from a feature branch
-to master in the same repository,
-in which case you can push commits
-to the feature branch directly.
-If the PR comes from a fork,
-you may have to make a PR
-on the feature branch in their repo.
-
-There are four types of commits that reviewers
-can add, depending on the type of change proposed.
+There are three types of commits that reviewers can add,
+depending on the type of change proposed.
 
 1. ``fixup`` commits should be used for minor changes
    like style fixes, moving code from one location to another,
@@ -160,15 +156,16 @@ can add, depending on the type of change proposed.
    In the end, your ``fixup`` commit will not appear in
    the history of the ``master`` branch.
 
-   To make a ``fixup`` commit, first make the desired changes
-   and ``git add`` them. When making the commit, do
-   ``git commit --fixup <commit hash>`` where the commit hash
-   corresponds to the commit that your ``fixup`` commit modifies.
+   To make a ``fixup`` commit, make your changes, then
 
-   ``fixup`` commits are so named because
-   the maintainer will ``fixup`` those commits into
-   the appropriate part of the PR branch's history
-   before merging that branch into ``master``.
+   .. code:: bash
+
+      git add -A
+      git commit --fixup <commit>
+
+   where ``<commit>`` corresponds to the commit
+   that your ``fixup`` commit modifies
+   (e.g., ``HEAD``, ``6be9830``).
 
 2. ``squash`` commits should be used for minor changes
    that require some explanation.
@@ -176,131 +173,76 @@ can add, depending on the type of change proposed.
    the history of the ``master`` branch,
    except in one or more commit messages.
 
-   To make a ``squash`` commit, first make the desired changes
-   and ``git add`` them. When making the commit, do
-   ``git commit --squash <commit hash>`` where the commit hash
-   corresponds to the commit that your ``squash`` commit modifies.
+   To make a ``squash`` commit, make your changes, then
+
+   .. code:: bash
+
+      git add -A
+      git commit --squash <commit hash>
+
    Unlike with the ``--fixup`` option, git will now prompt you
    to enter a message to explain what your ``squash`` commit does.
-
-   ``squash`` commits are so named because
-   the maintainer will ``squash`` those commits into
-   the appropriate part of the PR branch's history
-   before merging that branch into ``master``.
    Since ``squash`` commits contain a commit message,
    maintainers will review the message when merging
    that branch into ``master`` and incorporate it in
    the squashed commit message if appropriate.
 
 3. Normal commits should be used for major changes
-   that should be reflected in the ``master`` history.
-   A good rule of thumb to determine if your change
-   should be in a normal commit
-   is if you would be upset if that work was attributed
-   to someone else, as would happen for a ``fixup``
-   or ``squash`` commit.
-   If you're not sure,
-   feel free to make a normal commit anyway,
-   as the maintainer may choose to squash it regardless.
+   that should be reflected in the git history post-merge.
+   If you're not sure whether it should be in the history,
+   make a normal commit anyway
+   as the maintainer will reorganize history as they see fit.
 
-4. Commits in a separate branch should be used for
-   large and possibly controversial changes.
-   This typically happens when you end up essentially
-   reimplementing all of the content in the PR
-   but in a different way.
-   If you find that after your changes very little
-   of the original PR's changes remain,
-   then consider making your changes in a separate branch
-   and then making a PR from your branch to the original PR branch.
+Please note that
+all commits should be made at the end of the branch!
+The history of the PR branch should not be rewritten
+until it is being merged.
 
-It is important to note that none of the options listed above
-require rewriting the history of the PR branch.
-All commits should be made at the end of the branch
-so that regular pushes (not force pushes) can be used.
-If the PR branch is getting out of date
-and you wish to rebase the branch,
-ensure that no one else is assigned to the PR,
-assign yourself, and add a comment
-once you have force-pushed the rebased branch.
+4. Submitting a Github review
+-----------------------------
 
-Making a final decision
-=======================
+Once you've looked over the code
+and made your changes,
+finalize your review by submitting it through Github.
 
-In order to shorten the amount of back-and-forth
-in a given PR,
-we ask that reviewers make a decision about the PR
-and post that decision as a comment on the PR
-after making inline comments and commits.
+1. Click on the "Files changed" tab
+   underneath the title of the PR.
 
-Your decision should be one of the following:
+2. If you wish to point out specific changes that you made,
+   or specific parts of the code that need improvement,
+   `make an inline comment
+   <https://help.github.com/assets/images/help/commits/hover-comment-icon.gif>`_.
+   With your first inline comment,
+   click on the green "Start a review" button.
 
-1. This PR is good to merge, or will be good to merge with my changes.
-2. This PR could be good to merge, but it requires significant changes
-   that I am working on.
-3. This PR could be good to merge, but it requires significant changes.
-4. This PR is not appropriate for this project.
+3. Once you've left all your comments,
+   click on the "Review changes" button at the top-right of the page.
 
-For the second and third options,
-be mindful of people's time commitments.
-If the reviewer or PR author is not able
-to make the appropriate changes within 60 days,
-add the "revise and resubmit" label to the PR,
-make a comment on the PR, and close it.
-PRs can be reopened, so when that person
-gets time to work on it, they can either reopen
-the PR and add new commits,
-or make a new PR with the revised contribution.
+4. Write a review summary. This is **not** optional!
 
-The fourth option should not be taken lightly,
-but is necessary for the long-term success of a project.
-A PR left open too long is worse than a PR that is
-closed with a good reason and a clear next step.
-Never close a pull request without giving a reason
-and a next step for the PR author.
+   The summary is a good place to sum up your thoughts on the PR
+   and be explicit about next steps.
+   Even if you've left lots of nitpicky inline comments,
+   the tone of the review can be positive with a supportive review summary
+   (e.g., "I made lots of little style fixes,
+   but this improves the widget implementation significantly!").
 
-Here are some good reasons for closing a PR,
-with next steps.
+5. Decide to approve the PR or request changes,
+   and click "Submit review".
 
-1. This PR adds something that we do not think will be
-   used frequently, or duplicates existing functionality.
-   Please consider submitting this PR to
-   `nengo_extras <https://github.com/nengo/nengo_extras>`_,
-   another suitable place,
-   or make a separate repository for it and let us know
-   about that repository.
-2. This PR has some unresolved issues that have not been addressed
-   in a reasonable amount of time.
-   We would still like the changes in this PR,
-   so please address our comments and make a new PR
-   with those changes included.
-3. This PR causes tests to fail, and it's not clear
-   how to make the tests pass again.
-   Please get the tests to pass and resubmit this PR.
-   We are happy to help if parts of the code aren't clear!
+When writing feedback in comments or the review summary,
+clearly communicate when you feel strongly about a change,
+and when you are okay with the PR without that change.
+Offer alternative implementations,
+but assume the author has already considered them.
 
-This is by no means an exhaustive list,
-and PRs adding to this list are appreciated!
-For a longer discussion about
-the art of closing PRs,
-see `this blog post <https://blog.jessfraz.com/post/the-art-of-closing/>`_.
-
-Changing labels
-===============
-
-We use labels to keep track of the review status of each PR.
-Here are the conventions that we use.
-
-1. When a PR is created and ready for review,
-   the author or a maintainer will add the ``needs review`` label.
-2. If the first reviewer believes the PR is good to merge,
-   they remove the ``needs review`` label and add the
-   ``needs second review`` label.
-3. If the second reviewer also believes the PR is good to merge,
-   they remove the ``needs second review`` label and add the
-   ``reviewed`` label.
-4. If any reviewer believes the PR has unresolved issues,
-   they remove the ``needs review`` or ``needs second review``
-   label and add the ``needs changes`` label.
-5. If a PR with the ``needs changes`` label has not changed
-   in 60 days, add the ``revise and resubmit`` label
-   before closing the PR.
+Keep in mind that there is a difference
+in doing things right and doing things right now.
+Ideally, we should do things right,
+but a suboptimal PR often better than no PR at all.
+Asking the PR author to do major refactoring
+in the pull request is a big ask.
+These things can always happen later,
+unless you feel strongly that
+the current design
+will cause serious problems in the future.


### PR DESCRIPTION
Since we've now decided to use Github's PR reviewing interface and to explicitly assign reviewers, this document is now much shorter. This is based on #18 for convenience; I'll discuss these changes at the next dev meeting as well.