### PR TITLE
Treat warnings as errors in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - sphinx-build . _build
+  - sphinx-build -W . _build
 
 after_success:
   - if [[ $TRAVIS_BRANCH == 'src' ]]; then


### PR DESCRIPTION
Sphinx warns for some nice things, like when a section is referenced improperly, but builds them anyway. That's fine locally, but when testing PRs through TravisCI, it would be best if we disallow warnings.