### PR TITLE
Add documentation to projects page

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,11 +1,24 @@
 .project {
-    width: 100%;
     margin-top: 8px;
-    margin-bottom: 8px;
+    margin-bottom: 16px;
+    width: 100%;
+}
+
+.project:last-child {
+    margin-bottom: 0;
+}
+
+.project p {
+    margin-bottom: 4px;
+    margin-top: 3px;
 }
 
 .project strong {
     font-size: 120%;
+}
+
+.project-info strong a.external {
+    color: #333;
 }
 
 .project-info {

--- a/custom.py
+++ b/custom.py
@@ -2,7 +2,6 @@
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import StringList
 
 
 class Project(Directive):
@@ -20,6 +19,7 @@ class Project(Directive):
         "maintainer": directives.unchanged_required,
         "contact": directives.unchanged,
         "pypi": directives.unchanged,
+        "docs": directives.unchanged,
     }
     has_content = True
 
@@ -38,6 +38,7 @@ class Project(Directive):
         maintainer = self.options["maintainer"]
         contact = self.options.get("contact", None)
         pypi = self.options.get("pypi", None)
+        docs = self.options.get("docs", None)
 
         # Parent container holds info and description
         parent = nodes.container()
@@ -47,26 +48,38 @@ class Project(Directive):
         # Make a container for meta-info about the project
         info = nodes.container()
         info["classes"].append("project-info")
-        # Title contains name and Nengo team badge
+        # Title contains name, linked to docs if available
         title = nodes.strong(self.block_text, name)
+        if docs is not None:
+            title = nodes.strong(self.block_text)
+            title += nodes.reference(refuri=docs, text=name)
         info += title
 
+        shields = "https://img.shields.io"
         # Badges contains links to Github, PyPI, etc
         badges = nodes.paragraph(self.block_text)
         badges["classes"].append("project-badges")
+
+        if docs is not None:
+            badges += self.linked_image(
+                img="%s/badge/documentation--green.svg?style=social" % shields,
+                href=docs)
+
         badges += self.linked_image(
-            img="https://img.shields.io/github/stars/%s/%s"
-            ".svg?style=social&label=Github" % (org, repo),
+            img="%s/github/stars/%s/%s.svg?style=social&label=Github" % (
+                shields, org, repo),
             href="https://github.com/%s/%s" % (org, repo))
+
         if pypi is not None:
             badges += self.linked_image(
-                img="https://img.shields.io/pypi/v/%s.svg" % (pypi,),
+                img="%s/pypi/v/%s.svg" % (shields, pypi),
                 href="https://pypi.python.org/pypi/%s" % (pypi,))
         info += badges
 
         # List maintainer
         maint = nodes.paragraph(self.block_text)
         maint["classes"].append("project-maintainer")
+
         maint += nodes.inline(self.block_text, "Maintainer: ")
         if org == "nengo":
             maint += self.linked_image(
@@ -96,4 +109,4 @@ class Project(Directive):
 def setup(app):
     app.add_directive("project", Project)
 
-    return {"version": "0.1.0"}
+    return {"version": "0.1.1"}

--- a/projects.rst
+++ b/projects.rst
@@ -27,6 +27,7 @@ Core framework
    :maintainer: Trevor Bekolay
    :contact: tbekolay@gmail.com
    :pypi: nengo
+   :docs: http://pythonhosted.org/nengo/
 
    The core of the Nengo ecosystem is the
    Python library ``nengo``,
@@ -39,10 +40,11 @@ Core framework
    :repo: arvoelke/nengolib
    :maintainer: Aaron Voelker
    :contact: arvoelke@gmail.com
+   :docs: https://arvoelke.github.io/nengolib-docs/
 
    Additional extensions for large-scale brain modelling with Nengo.
-   See `basic usage <https://github.com/arvoelke/nengolib/blob/master/doc/notebooks/examples/basic_usage.ipynb>`_
-   for an introduction.
+   Includes advanced dynamics networks,
+   additional synapse models, and more.
 
 .. project:: Nengo extras
    :repo: nengo/nengo_extras
@@ -59,6 +61,7 @@ Core framework
    :repo: nengo/nengo.github.io
    :maintainer: Trevor Bekolay
    :contact: tbekolay@gmail.com
+   :docs: https://nengo.github.io/README.html
 
    You're reading the Nengo documentation right now!
    It contains general information about
@@ -69,6 +72,7 @@ Core framework
    :repo: nengo/enhancement_proposals
    :maintainer: Trevor Bekolay
    :contact: tbekolay@gmail.com
+   :docs: https://nengo.github.io/enhancement_proposals/
 
    Nengo Enhancement Proposals (NEPs) are proposals
    that touch multiple projects in the Nengo ecosystem,
@@ -139,6 +143,7 @@ faster or more accurately.
    :maintainer: Daniel Rasmussen
    :contact: dhrsmss@gmail.com
    :pypi: nengo_dl
+   :docs: http://nengo.github.io/nengo_dl/
 
    Nengo deep learning simulates Nengo models using
    the `TensorFlow <https://www.tensorflow.org/>`_ library


### PR DESCRIPTION
This is done by modifying the custom `project` directive to include a "docs" parameter, which should be a URL.

Fixes #24 (points to the nengolib docs now, instead of the now removed notebook).