### PR TITLE
Fix broken link in CAA

### DIFF
--- a/caa.rst
+++ b/caa.rst
@@ -14,7 +14,7 @@ This contributor agreement (the "Agreement") documents the rights
 granted by contributors to Us.
 
 By adding your name to the ``people.rst`` file at
-<https://github.com/nengo/nengo.github.io/blob/master/people.rst>
+<https://github.com/nengo/nengo.github.io/blob/src/people.rst>
 you are agreeing to be bound by the Agreement in full.
 
 You agree to inform Us in the relevant pull request(s) if You do not own

--- a/people.rst
+++ b/people.rst
@@ -12,6 +12,9 @@ not everyone on this list
 If you want to contact someone about a Nengo project,
 please contact the :ref:`project maintainer <Nengo projects>`.
 
+By adding your name to this file, you are agreeing to the
+`Nengo Contributor Assignment Agreement <https://www.nengo.ai/caa.html>`_.
+
 - Aaron Voelker <arvoelke@gmail.com>
 - Andreas Stöckel <andreas.stoeckel@gmail.com>
 - Andrew Mundy <andrew.mundy@ieee.org>


### PR DESCRIPTION
Also added a pointer from people.rst back to CAA (trying to ensure that people adding their name have read the CAA)