### PR TITLE
Summer school update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,14 @@ As with all Nengo projects,
 `issues and pull requests <https://github.com/nengo/nengo.github.io>`_
 are welcome!
 
-If you want to build the site locally to verify your changes, do
+If you want to build the site locally to verify your changes,
+install the requirements with
+
+.. code:: bash
+
+   pip install -r requirements.txt
+
+Then whenever you want to rebuild the site, do
 
 .. code:: bash
 

--- a/index.rst
+++ b/index.rst
@@ -33,7 +33,7 @@ for details).
    We've used Nengo to build Spaun,
    the world's largest functional brain model,
    which is described in
-   `this Science paper <http://nengo.ca/publications/spaunsciencepaper>`_.
+   `this Science paper <http://compneuro.uwaterloo.ca/publications/eliasmith2012.html>`_.
 
    .. raw:: html
 
@@ -53,6 +53,7 @@ for details).
    download
    projects
    build-a-brain/index
+   summerschool
    Forum <https://forum.nengo.ai>
    users
    developers

--- a/summerschool.rst
+++ b/summerschool.rst
@@ -5,25 +5,28 @@
 .. image:: _static/summerschool-campus.png
    :width: 100%
 
-**Introduction:**
+**Introducing Braindrop with Nengo**:
+
 The Centre for Theoretical Neuroscience
 at the University of Waterloo
-is currently accepting applications for our 5th annual
-summer school on large-scale brain modelling.
-This two-week school will teach participants
-how to use the Nengo simulation package
-to build state-of-the-art cognitive and neural models.
-Nengo has been used to build
-what is currently the world's largest
-functional brain model, Spaun,
-and provides users with a versatile and powerful environment
-for modelling cognitive and neural systems
-to run in simulation and on neuromorphic hardware.
-Nengo is also being used to program
-a variety of state-of-the-art neuromorphic chips,
-including the `Stanford Brains in Silicon
-<https://web.stanford.edu/group/brainsinsilicon/>`_
-'Braindrop' chip, which will be available at this year's summer school!
+is excited to announce a special version
+of our annual Nengo summer school that
+will host the **first public access to Braindrop**,
+a new mixed analog-digital neuromorphic chip
+developed in collaboration with Stanford and Yale.
+
+In addition to introducing Braindrop,
+this two-week school will teach participants
+to use the Nengo simulation package
+to build state-of-the-art cognitive and neural models
+to run both in simulation and on neuromorphic hardware.
+Nengo provides users with
+a versatile and powerful environment
+for designing cognitive and neural systems,
+and has been used to build what is currently
+the world's largest functional brain model, Spaun.
+Nengo is also being used to program a variety
+of state-of-the-art neuromorphic chips, including Braindrop!
 
 We welcome applications from all interested
 graduate students, research associates, postdocs,
@@ -65,6 +68,7 @@ develop new collaborations,
 and generate new ideas for projects.
 Participants will have the opportunity to learn how to:
 
+- interface Nengo with a variety of neuromorphic hardware systems, including Braindrop!
 - build models through detailed hands-on tutorials
 - build perceptual, motor, and cognitive models with spiking neurons
 - simulate large-scale models at a variety of levels of detail concurrently
@@ -73,7 +77,6 @@ Participants will have the opportunity to learn how to:
 - use a variety of single cell models within a large-scale model
 - use your favorite simulator, e.g. NEST, Brian, Neuron, etc.
 - integrate machine learning methods into biologically oriented models
-- interface Nengo with a variety of neuromorphic hardware systems, including Braindrop!
 - interface Nengo with cameras and robotic systems of various kinds
 - implement modern non-linear control methods in a neural model
 - and much more...
@@ -140,7 +143,7 @@ The application form is available
   https://www.dropbox.com/help/files-folders/create-file-request instead
 
 **Application deadline:**
-Applications are due on February 15th, 2018.
+Applications are due on **February 15th, 2018**.
 
 **Contact information:**
 For any questions,

--- a/summerschool.rst
+++ b/summerschool.rst
@@ -1,6 +1,6 @@
-*******************
-Nengo summer school
-*******************
+************************
+2018 Nengo Summer School
+************************
 
 .. image:: _static/summerschool-campus.png
    :width: 100%
@@ -8,8 +8,8 @@ Nengo summer school
 **Introduction:**
 The Centre for Theoretical Neuroscience
 at the University of Waterloo
-is currently running our 4th annual summer school
-on large-scale brain modelling.
+is currently accepting applications for our 5th annual
+summer school on large-scale brain modelling.
 This two-week school will teach participants
 how to use the Nengo simulation package
 to build state-of-the-art cognitive and neural models.
@@ -19,6 +19,12 @@ functional brain model, Spaun,
 and provides users with a versatile and powerful environment
 for modelling cognitive and neural systems
 to run in simulation and on neuromorphic hardware.
+Nengo is also being used to program
+a variety of state-of-the-art neuromorphic chips,
+including the `Stanford Brains in Silicon
+<https://web.stanford.edu/group/brainsinsilicon/>`_
+'Braindrop' chip, which will be available at this year's summer school!
+
 We welcome applications from all interested
 graduate students, research associates, postdocs,
 professors, and industry professionals.
@@ -30,7 +36,7 @@ computer science, robotics, neuromorphic engineering,
 or a related field.
 More information about Nengo,
 the Neural Engineering Framework, and Spaun
-can be found at http://www.nengo.ca.
+can be found at http://www.nengo.ai.
 Many of the concepts to be covered are in `this book
 <http://www.amazon.com/How-Build-Brain-Architecture-Architectures/dp/0199794545>`_.
 
@@ -67,7 +73,7 @@ Participants will have the opportunity to learn how to:
 - use a variety of single cell models within a large-scale model
 - use your favorite simulator, e.g. NEST, Brian, Neuron, etc.
 - integrate machine learning methods into biologically oriented models
-- interface Nengo with a variety of neuromorphic hardware
+- interface Nengo with a variety of neuromorphic hardware systems, including Braindrop!
 - interface Nengo with cameras and robotic systems of various kinds
 - implement modern non-linear control methods in a neural model
 - and much more...
@@ -87,7 +93,7 @@ The complete schedule and list of guest lecturers
 will be announced at a later date.
 
 **Dates:**
-June 4th - June 16th, 2017
+June 3th - June 15th, 2018
 
 **Location:**
 University of Waterloo, Ontario, Canada (`map <http://goo.gl/Sa074A>`_)
@@ -127,15 +133,15 @@ for these accommodations will be announced at a later date.
 **Applications:**
 To apply, you will need to submit a CV and a brief proposal for a project.
 The application form is available
-`here <https://script.google.com/macros/s/AKfycbwEZVZJoDvUbEbVAY7kph14hvlHk9OM6JdQi-n9YU6ZBffMemKt/exec>`__.
+`here <https://goo.gl/forms/9aZZRdYE4KMSwRXu2>`__.
 
 ..
   todo: consider using
   https://www.dropbox.com/help/files-folders/create-file-request instead
 
 **Application deadline:**
-Applications are due on February 15th, 2017.
+Applications are due on February 15th, 2018.
 
 **Contact information:**
 For any questions,
-please contact `Peter Blouw <mailto:pblouw@uwaterloo.ca>`_.
+please contact `Peter Blouw <mailto:peter.blouw@appliedbrainresearch.com>`_.

--- a/users.rst
+++ b/users.rst
@@ -157,7 +157,6 @@ Learning more
    :maxdepth: 1
 
    videos
-   summerschool
    publications
 
 Reference


### PR DESCRIPTION
This PR updates the summer school page to accept applications for 2018, and adds the summer school page to the main table of contents. I've also added a link to a google form that handles the application submissions (which I've tested with a sample application - results are hosted in the CNRG lab drive). 