### PR TITLE
Remove logos and reorganize docs page

### DIFF
--- a/documentation.rst
+++ b/documentation.rst
@@ -14,20 +14,14 @@ see :ref:`here <Nengo ecosystem>`.
 
 Jump to documentation for:
 
-.. |nengocore| image:: https://www.nengo.ai/design/_images/general-full-light.svg
-   :height: 50
-   :alt: Nengo core
-   :target: https://www.nengo.ai/nengo
+.. |nengocore| replace:: Nengo
+.. _nengocore: https://www.nengo.ai/nengo/
 
-.. |nengodl| image:: https://www.nengo.ai/design/_images/nengo-dl-full-light.svg
-   :height: 50
-   :alt: NengoDL
-   :target: https://www.nengo.ai/nengo-dl/
+.. |nengodl| replace:: Nengo DL
+.. _nengodl: https://www.nengo.ai/nengo-dl/
 
-.. |nengospa| image:: https://www.nengo.ai/design/_images/nengo-spa-full-light.svg
-   :height: 50
-   :alt: Nengo SPA
-   :target: https://www.nengo.ai/nengo-spa/
+.. |nengospa| replace:: Nengo SPA
+.. _nengospa: https://www.nengo.ai/nengo-spa/
 
 .. |nengogui| replace:: Nengo GUI
 .. _nengogui: https://github.com/nengo/nengo-gui
@@ -39,7 +33,7 @@ Jump to documentation for:
 .. _nengoextras: https://www.nengo.ai/nengo-extras/
 
 .. |nengofpga| replace:: Nengo FPGA
-.. _nengofpga: https://www.nengo.ai/nengo-fpga
+.. _nengofpga: https://www.nengo.ai/nengo-fpga/
 
 .. |nengoloihi| replace:: Nengo Loihi
 .. _nengoloihi: https://www.nengo.ai/nengo-loihi/
@@ -56,15 +50,19 @@ Jump to documentation for:
 .. |nengoexamples| replace:: Nengo Examples
 .. _nengoexamples: https://github.com/nengo/nengo-examples
 
-+------------------+----------------+-------------------+
-| |nengocore|      | |nengodl|      | |nengospa|        |
-+------------------+----------------+-------------------+
-| |nengogui|_      | |nengoextras|_ | |nengolib|_       |
-+------------------+----------------+-------------------+
-| |nengofpga|_     | |nengoloihi|_  | |nengospinnaker|_ |
-+------------------+----------------+-------------------+
-| |nengoexamples|_ | |nengoocl|_    | |nengompi|_       |
-+------------------+----------------+-------------------+
++-----------------+-----------------------+----------------------+
+| Core            | Backends              | Add-ons              |
++=================+=======================+======================+
+| |nengocore|_    | |nengofpga|_          | |nengoexamples|_     |
++-----------------+-----------------------+----------------------+
+| |nengodl|_      | |nengoloihi|_         | |nengoextras|_       |
++-----------------+-----------------------+----------------------+
+| |nengogui|_     | |nengompi|_           | |nengolib|_          |
++-----------------+-----------------------+----------------------+
+| |nengospa|_     | |nengoocl|_           |                      |
++-----------------+-----------------------+----------------------+
+|                 | |nengospinnaker|_     |                      |
++-----------------+-----------------------+----------------------+
 
 A few additional resources:
 


### PR DESCRIPTION
- Fixes #61 

Removed logos on the docs landing page for consistency and neatness, also reorganized the table to mirror navbar drop-down menu.