### PR TITLE
Add paragraph spacing in function parameters

### DIFF
--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -887,6 +887,14 @@ body.theme-purple {
     padding-left: 1em;
     margin-left: 0em;
     margin-bottom: 0em;
+
+    dd p:first-child {
+      margin-top: 0;
+    }
+
+    dd p {
+      margin-top: 0.5em;
+    }
   }
 
   .classifier {


### PR DESCRIPTION
Affects documentation sites built with Nengo Sphinx Theme.

See https://github.com/nengo/nengo-sphinx-theme/pull/44