### PR TITLE
Update to 2019 summer school video

### DIFF
--- a/summer-school.md
+++ b/summer-school.md
@@ -53,7 +53,7 @@ the summer school!
 
 <iframe width="100%"
     height="400"
-    src="https://www.youtube.com/embed/NwtYgBB2N6I"
+    src="https://www.youtube.com/embed/5w0BzvNOypc"
     frameborder="0"
     allowfullscreen
 ></iframe>


### PR DESCRIPTION
This is quick change to a YouTube link on the summer school page. I've tested a local build and the newly linked video displays properly. 