### PR TITLE
Fix CSS

### DIFF
--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -36,6 +36,7 @@ $enable-shadows: false; /* Disable shadows on elements - add manually using "sha
 
 /* App Styles */
 $header-height: 75px;
+$header-buffer: $header-height + 20px;
 
 body {
   padding: $header-height 0 0 0;
@@ -234,7 +235,7 @@ a {
 a.anchor {
   display: block;
   position: relative;
-  top: -($header-height + 20);
+  top: -$header-buffer;
   visibility: hidden;
 }
 
@@ -567,8 +568,8 @@ body.theme-purple {
   h5::before,
   h6::before {
     display: block;
-    height: 6rem;
-    margin-top: -6rem;
+    height: $header-buffer;
+    margin-top: -$header-buffer;
     visibility: hidden;
     content: "";
   }
@@ -866,6 +867,42 @@ body.theme-purple {
       padding-left: 3rem;
       border-left: 5px solid rgba(theme-color("dark"), 0.1);
     }
+  }
+
+  // add `before` to code table entries to account for top navbar in anchors
+  dl.class,
+  dl.function,
+  dl.attribute,
+  dl.method {
+    > dt::before {
+      content: "";
+      display: block;
+      height: $header-buffer;
+      margin-top: -$header-buffer;
+      background-color: none;
+    }
+
+    > dt:target::before {
+      // set background color to stop highlight from applying
+      background-color: #fff;
+    }
+  }
+
+  // add `before` to equations to account for top navbar in anchors
+  div.math::before {
+    content: "";
+    display: block;
+    height: $header-buffer;
+    margin-top: -$header-buffer;
+    visibility: hidden;
+  }
+  // add `before` to equation to align with equation
+  // (adding the previous `before` to `div.math` misaligned it)
+  span.eqno::before {
+    content: "";
+    display: block;
+    height: 1em;
+    visibility: hidden;
   }
 
   dl.field-list {

--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -817,11 +817,14 @@ body.theme-purple {
     color: darken(theme-color("blue"), 15%);
     background: rgba(theme-color("blue"), 0.1);
     padding: 0 1px;
+    // force code line height to be same height as normal lines
+    line-height: 80%;
   }
 
   a code {
     background-color: transparent;
     color: $link-color;
+    font-size: 100%;
   }
 
   table {

--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -384,7 +384,7 @@ h1,
   text-transform: uppercase;
 }
 
-h1, h2.uppercase {
+h1.uppercase, h2.uppercase {
   text-transform: uppercase;
 }
 
@@ -543,7 +543,6 @@ body.theme-purple {
     margin: 3rem 0;
     padding: 3rem 0;
     position: relative;
-    text-transform: uppercase;
     font-size: 54px;
 
     &::after {


### PR DESCRIPTION
Fix a number of CSS issues found in nengo-sphinx-theme

- Fixes nengo/nengo-sphinx-theme#42
- Fixes nengo/nengo-sphinx-theme#50
- Fixes nengo/nengo-sphinx-theme#43

We really ought to fix the anchors for tables, too, but I can't figure out how to do that (using `::before` with a table adds the space between the header and the first row, not before the header).