### PR TITLE
Fix links to underscored examples (including single_neuron.ipynb)

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -25,12 +25,6 @@ in the file view at the top-left.
 - `tutorial` is a set of 25 guided examples going from a network of one neuron
   to networks of hundreds of thousands of neurons implementing cognitive models.
 
-## Standard neural networks
-
-- [Hopfield networks](https://github.com/s72sue/std_neural_nets/blob/master/hopfield_network.ipynb)
-- [Perceptron computing XOR](https://github.com/s72sue/std_neural_nets/blob/master/computing_functions/perceptron_for_XOR.ipynb)
-- [4-class classification](https://github.com/s72sue/std_neural_nets/blob/master/classification/4-class_classification.ipynb)
-
 ## Deep learning
 
 - [Coming from TensorFlow to NengoDL](https://www.nengo.ai/nengo-dl/examples/from-tensorflow.html)

--- a/examples.md
+++ b/examples.md
@@ -41,21 +41,21 @@ in the file view at the top-left.
 
 ## Neuromorphic hardware
 
-- [Keyword spotting with Nengo Loihi](https://www.nengo.ai/nengo-loihi/examples/keyword_spotting.html)
-- [Nonlinear adaptive control with Nengo Loihi](https://www.nengo.ai/nengo-loihi/examples/adaptive_motor_control.html)
-- [CIFAR-10 convolutional network](https://github.com/nengo/nengo-examples/blob/master/loihi-dl/cifar10_convnet.ipynb)
+- [Keyword spotting with Nengo Loihi](https://www.nengo.ai/nengo-loihi/examples/keyword-spotting.html)
+- [Nonlinear adaptive control with Nengo Loihi](https://www.nengo.ai/nengo-loihi/examples/adaptive-motor-control.html)
+- [CIFAR-10 convolutional network](https://github.com/nengo/nengo-examples/blob/master/loihi-dl/cifar10-convnet.ipynb)
 - [Other Nengo Loihi examples](https://www.nengo.ai/nengo-loihi/examples.html)
 
 ## Online learning
 
-- [Supervised learning with the PES learning rule](https://www.nengo.ai/nengo/examples/learning/learn_communication_channel.html)
+- [Supervised learning with the PES learning rule](https://www.nengo.ai/nengo/examples/learning/learn-communication-channel.html)
 - [Supervised FORCE learning with the RLS learning rule](https://arvoelke.github.io/nengolib-docs/notebooks/examples/full_force_learning.html)
-- [Unsupervised association learning with the Voja learning rule](https://www.nengo.ai/nengo/examples/learning/learn_associations.html)
-- [Unsupervised synaptic plasticity rules](https://www.nengo.ai/nengo/examples/learning/learn_unsupervised.html)
+- [Unsupervised association learning with the Voja learning rule](https://www.nengo.ai/nengo/examples/learning/learn-associations.html)
+- [Unsupervised synaptic plasticity rules](https://www.nengo.ai/nengo/examples/learning/learn-unsupervised.html)
 
 ## Neural Engineering Framework
 
-- [Summary of the NEF principles](https://www.nengo.ai/nengo/examples/advanced/nef_summary.html)
+- [Summary of the NEF principles](https://www.nengo.ai/nengo/examples/advanced/nef-summary.html)
 - [Nengo core examples](https://www.nengo.ai/nengo/examples)
 - [Spiking MNIST with Gabor encoders](https://www.nengo.ai/nengo-extras/examples/mnist_single_layer.html)
 - [Computing functions across a rolling window of time (LMU)](https://arvoelke.github.io/nengolib-docs/notebooks/examples/rolling_window.html)
@@ -63,5 +63,5 @@ in the file view at the top-left.
 ## Cognitive modelling with SPA
 
 - [Spaun](https://github.com/xchoo/spaun2.0)
-- [Simple question answering with the Semantic Pointer Architecture](https://www.nengo.ai/nengo-spa/examples/question_memory.html)
+- [Simple question answering with the Semantic Pointer Architecture](https://www.nengo.ai/nengo-spa/examples/question-memory.html)
 - [Nengo SPA examples](https://www.nengo.ai/nengo-spa/examples.html)

--- a/getting-started.md
+++ b/getting-started.md
@@ -116,15 +116,16 @@ The [Jupyter notebook](http://jupyter.org/) provides another way to run
 Python scripts. We provide Nengo core examples as Jupyter notebooks
 because you can see plots in the same interface as the code. Jupyter
 notebooks are also text files, but have the extension `.ipynb`. These
-are run through the Jupyter notebook. For example, after downloading
-[single\_neuron.ipynb](https://github.com/nengo/nengo/blob/master/docs/examples/basic/single_neuron.ipynb),
-you can start the notebook like this:
+are run through the Jupyter notebook. To try this out, download
+<a href="https://raw.githubusercontent.com/nengo/nengo/master/docs/examples/basic/single-neuron.ipynb" target="_blank" download>single-neuron.ipynb</a>
+(press Ctrl+s to save the notebook if it doesn't download automatically).
+Then open a terminal, enter
 
 ```bash
 $ jupyter notebook
 ```
 
-and then click on `single_neuron.ipynb` to run the example.
+and click on `single-neuron.ipynb` to run the example.
 
 To access a series of tutorials that use Nengo with a Python
 interpreter, [see the Nengo
@@ -141,4 +142,4 @@ documentation](https://www.nengo.ai/nengo/examples.html).
 The following links are useful to refer to when building models.
 
 - [Nengo core documentation](https://www.nengo.ai/nengo/)
-- [Nengo modelling API](https://www.nengo.ai/nengo/frontend_api.html)
+- [Nengo modelling API](https://www.nengo.ai/nengo/frontend-api.html)


### PR DESCRIPTION
We use hyphens in example filenames now. Also, the notebook in the getting started section should be directly downloaded if possible.

Fixes #109 and supersedes #111.