### PR TITLE
Account for top navbar in code links

### DIFF
--- a/css/bootstrap.scss
+++ b/css/bootstrap.scss
@@ -859,6 +859,15 @@ body.theme-purple {
     float: right;
   }
 
+  // add `before` to code blocks to account for top navbar in anchors
+  div.viewcode-block::before {
+    content: "";
+    display: block;
+    height: $header-buffer;
+    margin-top: -$header-buffer;
+    visibility: hidden;
+  }
+
   dl.class,
   dl.function {
     > dt {


### PR DESCRIPTION
Same idea as fixing the alignment for other objects in #102, but now applied to code blocks.