### PR TITLE
Fix link to spiking action planning paper

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -86,7 +86,7 @@ heteroassociative memory using the Neural Engineering Framework. *The
 Blouw, Eliasmith, & Tripp (2016) A scaleable spiking neural model of
 action planning. In *Proceedings of the 37th Annual Conference of the
 Cognitive Science Society*. Austin, TX: Cognitive Science Society.
-[PDF](https://mindmodeling.org/cogsci2016/papers/0279/paper0279.pdf)
+[PDF](https://www.researchgate.net/publication/307858522_A_scaleable_spiking_neural_model_of_action_planning)
 
 Kröger, Crawford, Bekolay, & Eliasmith (2016) Modeling interactions
 between speech production and perception: speech error detection at


### PR DESCRIPTION
The old link died. It appears that MindModeling.org has been down for a while; I'm guessing it won't come back up. So I'm using a ResearchGate link instead. (The proceedings are also available on the [CogSci website](https://cognitivesciencesociety.org/past-conferences/), but all the papers are in one giant PDF, which is a bit cumbersome.)