### PR TITLE
Add new name for Fall 2021 Co-op term

### DIFF
--- a/people.md
+++ b/people.md
@@ -44,7 +44,7 @@ By adding your name to this file, you are agreeing to the
 - [Ivana Kajić](mailto:ivana.kajic@gmail.com)
 - [James Bergstra](mailto:james.bergstra@gmail.com)
 - [Jan Gosmann](mailto:jan@hyper-world.de)
-- [Jonathan Chalaturnyk](mailto:jonathan.chalaturnyk@appliedbrainresearch.com)
+- [Jonathan Chalaturnyk](mailto:jrchalaturnyk@gmail.com)
 - [Kimathi Kaai](mailto:kimathikaai@gmail.com)
 - [Kinjal Patel](mailto:kinjalp.patel@mail.utoronto.ca)
 - [Kris Frenette](mailto:kris.frenette@appliedbrainresearch.com)

--- a/people.md
+++ b/people.md
@@ -44,6 +44,7 @@ By adding your name to this file, you are agreeing to the
 - [Ivana Kajić](mailto:ivana.kajic@gmail.com)
 - [James Bergstra](mailto:james.bergstra@gmail.com)
 - [Jan Gosmann](mailto:jan@hyper-world.de)
+- [Jonathan Chalaturnyk](mailto:jonathan.chalaturnyk@appliedbrainresearch.com)
 - [Kimathi Kaai](mailto:kimathikaai@gmail.com)
 - [Kinjal Patel](mailto:kinjalp.patel@mail.utoronto.ca)
 - [Kris Frenette](mailto:kris.frenette@appliedbrainresearch.com)


### PR DESCRIPTION
Adding Jonathan Chalaturnyk to people.md as part of Fall 2021 Co-op onboarding and Nengo CAA.